### PR TITLE
GITHUB ISSUE C47 & C48: Store Moves Across Multiple Games & Allow Game Replay

### DIFF
--- a/ConnectFour/Display.cs
+++ b/ConnectFour/Display.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Pastel;
 
 namespace ConnectFour
@@ -10,10 +11,40 @@ namespace ConnectFour
         {
             Console.WriteLine("-------------------------------------\n" +
                                 "~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~\n" +
-                                "~*~*~*~*~*~ CONNECT FOUR ~*~*~*~*~*~\n" + 
+                                "~*~*~*~*~*~ CONNECT FOUR ~*~*~*~*~*~\n" +
                                 "~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~*~\n" +
                                 "-------------------------------------\n\n" +
-                                "Welcome to Connect Four!\n\n"); 
+                                "Welcome to Connect Four!\n");
+        }
+
+        public void StartMenu()
+        {
+            Console.WriteLine("Select an option:\n" +
+                                "1. Start New Game\n" +
+                                "2. Replay Previous Game\n");
+        }
+
+        public int GetStartMenuSelection()
+        {
+            bool success;
+            int input;
+
+            success = Int32.TryParse(Console.ReadLine(), out input);
+            if (success)
+            {
+                if (input == 1 || input == 2)
+                {
+                    return input;
+                }
+                else
+                {
+                    throw new Exception("Please select a valid option from the menu.");
+                }
+            }
+            else
+            {
+                throw new Exception("Please select a valid option from the menu.");
+            }
         }
 
         public void GameHeader(Game game)
@@ -61,16 +92,16 @@ namespace ConnectFour
         }
 
         // Print formatted board in its current state
-        public void PrintBoard(Board board)
+        public void PrintBoard(Game game)
         {
             // Array to store each formatted row in the board
-            string[] rows = new string[board.Height];
+            string[] rows = new string[game.Board.Height];
             string bottomRow = "";
             int row = 0;
 
             // Get height (1-26) and width (A-Z) values of board depending on custom height/width
-            char[] xAxis = board.GetXAxis(board.Width);
-            int[] yAxis = board.GetYAxis(board.Height);
+            char[] xAxis = game.Board.GetXAxis(game.Board.Width);
+            int[] yAxis = game.Board.GetYAxis(game.Board.Height);
             
             Console.WriteLine("");
             
@@ -78,7 +109,7 @@ namespace ConnectFour
             foreach (int y in yAxis)
             {
                 // Array to store all slots in that row
-                Slot[] rowSlots = new Slot[board.Width];
+                Slot[] rowSlots = new Slot[game.Board.Width];
                 int column = 0;
                 // String to build formatted row
                 string printLine = "";
@@ -103,7 +134,7 @@ namespace ConnectFour
                 foreach (Slot rowSlot in rowSlots)
                 {
                     Slot slot;
-                    if (board.Slots.TryGetValue((rowSlot.XCoordinate.ToString() + rowSlot.YCoordinate), out slot))
+                    if (game.Board.Slots.TryGetValue((rowSlot.XCoordinate.ToString() + rowSlot.YCoordinate), out slot))
                     {
                         // Player 1 slots are yellow
                         if (slot.Content == 1)
@@ -155,7 +186,7 @@ namespace ConnectFour
         }
 
         // Allow player to enter move and update board accordingly
-        public void PlayMove(Board board, Game game)
+        public void PlayMove(Game game)
         {
             Player currentPlayer;
             string input = "";
@@ -177,17 +208,17 @@ namespace ConnectFour
                 input = Console.ReadLine();
             }
             // Check move is valid
-            if (game.ValidMove(input, board))
+            if (game.ValidMove(input))
             {
                 // Add move to stack
-                Slot move = game.NextAvailableSlot(input, board);
-                game.MakeMove(move, currentPlayer, board);
+                Slot move = game.NextAvailableSlot(input);
+                game.MakeMove(move, currentPlayer);
             }
             else if (input == "1")
             {
                 try
                 {
-                    game.UndoMove(board);
+                    game.UndoMove();
                 }
                 catch(Exception e)
                 {
@@ -198,7 +229,7 @@ namespace ConnectFour
             {
                 try
                 {
-                    game.RedoMove(board);
+                    game.RedoMove();
                 }
                 catch(Exception e)
                 {
@@ -212,18 +243,113 @@ namespace ConnectFour
         }
 
         // Remove the board from console and print latest version of board
-        public void UpdateBoard(Board board, Game game)
+        public void UpdateBoard(Game game)
         {
             Console.Clear();
             Welcome();
             GameHeader(game);
-
-            PrintBoard(board);
+            PrintBoard(game);
         }
 
+        // Display congratulatory message to game winner, before returning to main menu on key press
         public void Winner(Player winner)
         {
-            Console.WriteLine("\nCongratulations " + winner.Name + " you WIN !!!");
+            Console.WriteLine("\nCongratulations " + winner.Name + " you WIN !!!\n"
+                            + "Press any key to continue...");
+            Console.ReadKey();
+            // Return to main menu
+            Console.Clear();
+            Welcome();
+            StartMenu();
+        }
+
+        // Allow user to select a previous game and replay it
+        public void ReplayGame(List<Game> games)
+        {
+            if (games.Count > 0)
+            {
+                int count = 0;
+                int gameToReplay;
+                bool success;
+
+                Console.Clear();
+                Welcome();
+
+                // Display list of previous games
+                Console.WriteLine("Which game do you want to replay?\n");
+                foreach (Game game in games)
+                {
+                    count++;
+                    Console.WriteLine(count + ". " + game.Players[0].Name + " vs. " + game.Players[1].Name + "\n");
+                }
+
+                // Get user selection
+                success = Int32.TryParse(Console.ReadLine(), out gameToReplay);
+                if (success)
+                {
+                    if (gameToReplay > 0 && gameToReplay <= games.Count)
+                    {
+                        // Identify the game they wish to replay
+                        Game replay = games[gameToReplay - 1];
+                        Stack<KeyValuePair<Slot,Player>> replayMoves = ReverseMoves(replay.Moves);
+
+                        // Clear the game board
+                        foreach (KeyValuePair<string, Slot> slot in replay.Board.Slots)
+                        {
+                            slot.Value.Content = 0;
+                        }
+
+                        // Reset console
+                        Console.Clear();
+                        Welcome();
+                        Console.WriteLine("--- LIVE ACTION REPLAY ---\n"
+                                        + replay.Players[0].Name + " VS. " + replay.Players[1].Name);
+                        PrintBoard(replay);
+
+                        // Replay game
+                        foreach (KeyValuePair<Slot, Player> move in replayMoves)
+                        {
+                            Console.Clear();
+                            Welcome();
+                            Console.WriteLine("--- LIVE ACTION REPLAY ---\n"
+                                        + replay.Players[0].Name + " VS. " + replay.Players[1].Name);
+                            replay.MakeMove(move.Key, move.Value);
+                            PrintBoard(replay);
+                            System.Threading.Thread.Sleep(500);
+                        }
+
+                        Console.WriteLine("\n" + replay.Moves.Peek().Value.Name + " won!");
+                        Console.WriteLine("\nPress any key to continue...");
+                        Console.ReadKey();
+                        // Return to main menu
+                        Console.Clear();
+                        Welcome();
+                        StartMenu();
+                    }
+                    else
+                    {
+                        throw new Exception("Invalid menu selection.");
+                    }
+                }
+                else
+                {
+                    throw new Exception("Invalid menu selection.");
+                }
+            }
+            else
+            {
+                throw new Exception("No previous games to replay");
+            }
+        }
+
+        public Stack<KeyValuePair<Slot, Player>> ReverseMoves(Stack<KeyValuePair<Slot, Player>> moves)
+        {
+            Stack<KeyValuePair<Slot, Player>> reverse = new Stack<KeyValuePair<Slot, Player>>();
+            foreach(KeyValuePair<Slot, Player> move in moves)
+            {
+                reverse.Push(move);
+            }
+            return reverse;
         }
     }
 }

--- a/ConnectFour/Display.cs
+++ b/ConnectFour/Display.cs
@@ -26,15 +26,15 @@ namespace ConnectFour
 
         public int GetStartMenuSelection()
         {
-            bool success;
-            int input;
+            bool validInt;
+            int userInput;
 
-            success = Int32.TryParse(Console.ReadLine(), out input);
-            if (success)
+            validInt = Int32.TryParse(Console.ReadLine(), out userInput);
+            if (validInt)
             {
-                if (input == 1 || input == 2)
+                if (userInput == 1 || userInput == 2)
                 {
-                    return input;
+                    return userInput;
                 }
                 else
                 {
@@ -270,7 +270,7 @@ namespace ConnectFour
             {
                 int count = 0;
                 int gameToReplay;
-                bool success;
+                bool validInt;
 
                 Console.Clear();
                 Welcome();
@@ -284,8 +284,8 @@ namespace ConnectFour
                 }
 
                 // Get user selection
-                success = Int32.TryParse(Console.ReadLine(), out gameToReplay);
-                if (success)
+                validInt = Int32.TryParse(Console.ReadLine(), out gameToReplay);
+                if (validInt)
                 {
                     if (gameToReplay > 0 && gameToReplay <= games.Count)
                     {

--- a/ConnectFour/Game.cs
+++ b/ConnectFour/Game.cs
@@ -9,6 +9,7 @@ namespace ConnectFour
         private Stack<KeyValuePair<Slot, Player>> _moves = new Stack<KeyValuePair<Slot, Player>>();
         private Stack<KeyValuePair<Slot, Player>> _redoMoves = new Stack<KeyValuePair<Slot, Player>>();
         private Player[] _players = new Player[2];
+        private Board _board = new Board();
         private int _firstPlayer;
 
         public Game(Player player1, Player player2)
@@ -18,7 +19,7 @@ namespace ConnectFour
         }
 
         // Establish whether a player has won based on last move made
-        public bool Winner(Board board, Player player)
+        public bool Winner (Player player)
         {
             char x = char.ToUpper(_moves.Peek().Key.XCoordinate);
             int y = _moves.Peek().Key.YCoordinate;
@@ -40,53 +41,53 @@ namespace ConnectFour
 
                 char something = ((char)((int)x + i));
 
-                if (((int)x+i) >= 65 && ((int)x + i) <= (64 + board.Width) 
-                    && (y + i) > 0 && (y + i) <= board.Height)
+                if (((int)x+i) >= 65 && ((int)x + i) <= (64 + _board.Width) 
+                    && (y + i) > 0 && (y + i) <= _board.Height)
                 {
                     A = ((char)((int)x + i)).ToString() + (y + i);
                     diagonalSlotsA.Add(3 + i, A);
                 }
 
-                if (((int)x - i) >= 65 && ((int)x - i) <= (64 + board.Width)
-                    && (y - i) > 0 && (y - i) <= board.Height)
+                if (((int)x - i) >= 65 && ((int)x - i) <= (64 + _board.Width)
+                    && (y - i) > 0 && (y - i) <= _board.Height)
                 {
                     B = ((char)((int)x - i)).ToString() + (y - i);
                     diagonalSlotsA.Add(3 - i, B);
                 }
 
-                if (((int)x - i) >= 65 && ((int)x - i) <= (64 + board.Width)
-                    && (y + i) > 0 && (y + i) <= board.Height)
+                if (((int)x - i) >= 65 && ((int)x - i) <= (64 + _board.Width)
+                    && (y + i) > 0 && (y + i) <= _board.Height)
                 {
                     C = ((char)((int)x - i)).ToString() + (y + i);
                     diagonalSlotsB.Add(3 - i, C);
                 }
 
-                if (((int)x + i) >= 65 && ((int)x + i) <= (64 + board.Width)
-                    && (y - i) > 0 && (y - i) <= board.Height)
+                if (((int)x + i) >= 65 && ((int)x + i) <= (64 + _board.Width)
+                    && (y - i) > 0 && (y - i) <= _board.Height)
                 {
                     D = ((char)((int)x + i)).ToString() + (y - i);
                     diagonalSlotsB.Add(3 + i, D);
                 }
 
-                if ((y + i) > 0 && (y + i) <= board.Height)
+                if ((y + i) > 0 && (y + i) <= _board.Height)
                 {
                     E = x.ToString() + (y + i);
                     horizontalSlots.Add(3 + i, E);
                 }
 
-                if ((y - i) > 0 && (y - i) <= board.Height)
+                if ((y - i) > 0 && (y - i) <= _board.Height)
                 {
                     F = x.ToString() + (y - i);
                     horizontalSlots.Add(3 - i, F);
                 }
 
-                if (((int)x - i) >= 65 && ((int)x - i) <= (64 + board.Width))
+                if (((int)x - i) >= 65 && ((int)x - i) <= (64 + _board.Width))
                 {
                     G = ((char)((int)x - i)).ToString() + y;
                     verticalSlots.Add(3 - i, G);
                 }
 
-                if (((int)x + i) >= 65 && ((int)x + i) <= (64 + board.Width))
+                if (((int)x + i) >= 65 && ((int)x + i) <= (64 + _board.Width))
                 {
                     H = ((char)((int)x + i)).ToString() + y;
                     verticalSlots.Add(3 + i, H);
@@ -94,10 +95,10 @@ namespace ConnectFour
             }
                 
             // Check if four consecutive slots have been filled by player
-            if (FourInARow(diagonalSlotsA, board, player)
-                || FourInARow(diagonalSlotsB, board, player)
-                || FourInARow(horizontalSlots, board, player)
-                || FourInARow(verticalSlots, board, player))
+            if (FourInARow(diagonalSlotsA, player)
+                || FourInARow(diagonalSlotsB, player)
+                || FourInARow(horizontalSlots, player)
+                || FourInARow(verticalSlots, player))
             {
                 return true;
             }
@@ -108,7 +109,7 @@ namespace ConnectFour
         }
 
         // Establish whether 4 consecutive slots have been populated by player
-        public bool FourInARow(SortedList checkSlots, Board board, Player player)
+        public bool FourInARow(SortedList checkSlots, Player player)
         {
             bool fourUp = false;
             try
@@ -117,13 +118,13 @@ namespace ConnectFour
                 {
                     for (int i = 0; i < 4; i++)
                     {
-                        if (board.Slots[checkSlots.GetByIndex(i).ToString()].Content == PlayerNumber(player.Name))
+                        if (_board.Slots[checkSlots.GetByIndex(i).ToString()].Content == PlayerNumber(player.Name))
                         {
-                            if (board.Slots[checkSlots.GetByIndex(i + 1).ToString()].Content == PlayerNumber(player.Name))
+                            if (_board.Slots[checkSlots.GetByIndex(i + 1).ToString()].Content == PlayerNumber(player.Name))
                             {
-                                if (board.Slots[checkSlots.GetByIndex(i + 2).ToString()].Content == PlayerNumber(player.Name))
+                                if (_board.Slots[checkSlots.GetByIndex(i + 2).ToString()].Content == PlayerNumber(player.Name))
                                 {
-                                    if (board.Slots[checkSlots.GetByIndex(i + 3).ToString()].Content == PlayerNumber(player.Name))
+                                    if (_board.Slots[checkSlots.GetByIndex(i + 3).ToString()].Content == PlayerNumber(player.Name))
                                     {
                                         fourUp = true;
                                     }
@@ -141,11 +142,11 @@ namespace ConnectFour
         }
 
         // Establish whether or not the move entered by player is valid
-        public bool ValidMove(string move, Board board)
+        public bool ValidMove(string move)
         {
             bool validX = false;
             bool columnEmpty = false;
-            char[] xAxis = board.GetXAxis(board.Width);
+            char[] xAxis = _board.GetXAxis(_board.Width);
 
             // Ensure that only 1 character is entered
             if (move.Length == 1)
@@ -163,10 +164,10 @@ namespace ConnectFour
                 if (validX)
                 {
                     // Check that the column has empty slots
-                    for (int i = 0; i < board.Height; i++)
+                    for (int i = 0; i < _board.Height; i++)
                     {
                         string slot = x.ToString().ToUpper() + (i + 1).ToString();
-                        if (board.Slots[slot].Content == 0)
+                        if (_board.Slots[slot].Content == 0)
                         {
                             columnEmpty = true;
                         }
@@ -189,12 +190,12 @@ namespace ConnectFour
         }
 
         // Get coordinates of the next available slot in chosen column
-        public Slot NextAvailableSlot(string column, Board board)
+        public Slot NextAvailableSlot(string column)
         {
-            for (int i = 0; i < board.Height; i++)
+            for (int i = 0; i < _board.Height; i++)
             {
                 string slot = column.ToUpper() + (i + 1).ToString();
-                if (board.Slots[slot].Content == 0)
+                if (_board.Slots[slot].Content == 0)
                 {
                     Slot nextAvailable = new Slot(char.Parse(column), (i + 1));
                     return nextAvailable;
@@ -249,11 +250,11 @@ namespace ConnectFour
             return currentPlayer;
         }
         
-        public void MakeMove(Slot slot, Player player, Board board)
+        public void MakeMove(Slot slot, Player player)
         {
             // Update position on board
             string moveLocation = slot.XCoordinate.ToString().ToUpper() + slot.YCoordinate.ToString();
-            board.Slots[moveLocation].Content = PlayerNumber(player.Name);
+            _board.Slots[moveLocation].Content = PlayerNumber(player.Name);
 
             // Add to stack of game moves
             KeyValuePair<Slot, Player> move = new KeyValuePair<Slot, Player>(slot, player);
@@ -261,7 +262,7 @@ namespace ConnectFour
         }
         
         // Undo the last move made
-        public void UndoMove(Board board)
+        public void UndoMove()
         {
             if (_moves.Count > 0)
             {
@@ -271,7 +272,7 @@ namespace ConnectFour
 
                 // Update position on board
                 string undoMoveLocation = undoMove.Key.XCoordinate.ToString().ToUpper() + undoMove.Key.YCoordinate.ToString();
-                board.Slots[undoMoveLocation].Content = 0;
+                _board.Slots[undoMoveLocation].Content = 0;
             }
             else
             {
@@ -280,7 +281,7 @@ namespace ConnectFour
         }
 
         // Redo the last move undone
-        public void RedoMove(Board board)
+        public void RedoMove()
         {
             if (_redoMoves.Count > 0)
             {
@@ -290,12 +291,18 @@ namespace ConnectFour
 
                 // Update position on board
                 string redoMoveLocation = redoMove.Key.XCoordinate.ToString().ToUpper() + redoMove.Key.YCoordinate.ToString();
-                board.Slots[redoMoveLocation].Content = PlayerNumber(redoMove.Value.Name);
+                _board.Slots[redoMoveLocation].Content = PlayerNumber(redoMove.Value.Name);
             }
             else
             {
                 throw new Exception("No moves to redo!");
             }
+        }
+
+        public Board Board
+        {
+            get => _board;
+            set => _board = value;
         }
 
         public Player[] Players

--- a/ConnectFour/Program.cs
+++ b/ConnectFour/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace ConnectFour
 {
@@ -6,78 +7,131 @@ namespace ConnectFour
     {
         static void Main(string[] args)
         {
-            Board board = new Board();
+            List<Game> games = new List<Game>();
             Display display = new Display();
             bool boardSizeValid = true;
             bool moveValid = true;
+            bool startMenuValid = true;
+            bool restart = true;
 
-            // Display welcome message
-            display.Welcome();
-
-            // Establish players - user enters player names
-            Player player1 = display.GetPlayer(1);
-            Player player2 = display.GetPlayer(2);
-
-            // Insantiate new game of players
-            Game game = new Game(player1,player2);
-            bool winner = false;
             do
             {
-                try
-                {
-                    // Establish size of board - user enters custom height/width
-                    int height = display.GetBoardSize("Board height (4 - 26): ");
-                    int width = display.GetBoardSize("Board width (4 - 26): ");
-                
-                    // Initialise and display board
-                    board.InitBoard(height, width);
-                    boardSizeValid = true;
-                }
-                catch (Exception e)
-                {
-                    // Throw error message if board height/width parameters are invalid
-                    Console.WriteLine(e.Message);
-                    boardSizeValid = false;
-                }
+                Console.Clear();
+                // Display welcome message
+                display.Welcome();
+                display.StartMenu();
 
-            } while (!boardSizeValid);
-
-            // Display game information & pick 1st player at random
-            display.BeginGame(game);
-            // Display Connect Four board
-            display.PrintBoard(board);
-            do
-            {
-
-                try
+                do
                 {
-                    moveValid = true;
-                    // Allow current player to make move
-                    display.PlayMove(board, game);
-                    // Update Connect Four board to display move made
-                    display.UpdateBoard(board, game);
-                    // Check if current player has won after minimum 7 moves have been made
-                    if (game.Moves.Count >= 7)
+                    try
                     {
-                        winner = game.Winner(board, game.CurrentPlayer());
+                        // Display start menu and retrieve user option (1 - new game, 2 - replay)
+                        int option = display.GetStartMenuSelection();
+
+                        // If user selects 'new game'...
+                        if (option == 1)
+                        {
+                            startMenuValid = true;
+                            // Establish players - user enters player names
+                            Player player1 = display.GetPlayer(1);
+                            Player player2 = display.GetPlayer(2);
+
+                            // Insantiate new game of players
+                            Game game = new Game(player1, player2);
+                            bool winner = false;
+                            do
+                            {
+                                try
+                                {
+                                    // Establish size of board - user enters custom height/width
+                                    int height = display.GetBoardSize("Board height (4 - 26): ");
+                                    int width = display.GetBoardSize("Board width (4 - 26): ");
+
+                                    // Initialise and display board
+                                    game.Board.InitBoard(height, width);
+                                    boardSizeValid = true;
+                                }
+                                catch (Exception e)
+                                {
+                                    // Throw error message if board height/width parameters are invalid
+                                    Console.WriteLine(e.Message);
+                                    boardSizeValid = false;
+                                }
+
+                            } while (!boardSizeValid);
+
+                            // Display game information & pick 1st player at random
+                            display.BeginGame(game);
+                            // Display Connect Four board
+                            display.PrintBoard(game);
+                            do
+                            {
+
+                                try
+                                {
+                                    moveValid = true;
+                                    // Allow current player to make move
+                                    display.PlayMove(game);
+                                    // Update Connect Four board to display move made
+                                    display.UpdateBoard(game);
+                                    // Check if current player has won after minimum 7 moves have been made
+                                    if (game.Moves.Count >= 7)
+                                    {
+                                        winner = game.Winner(game.CurrentPlayer());
+                                    }
+                                }
+                                catch (Exception e)
+                                {
+                                    // Throw error message if invalid move is made
+                                    Console.WriteLine(e.Message);
+                                    moveValid = false;
+                                }
+                            }
+                            // Repeat while move is invalid or neither player has won
+                            while (!moveValid || !winner);
+
+                            if (winner)
+                            {
+                                // Store game in session history
+                                games.Add(game);
+                                // Display congratulatory message to winner
+                                display.Winner(game.CurrentPlayer());
+                            }
+                        }
+                        // If user selects 'replay game'...
+                        else if (option == 2)
+                        {
+                            startMenuValid = true;
+                            bool selectReplay = true;
+                            do
+                            {
+                                try
+                                {
+                                    display.ReplayGame(games);
+                                    selectReplay = true;
+                                }
+                                catch (Exception e)
+                                {
+                                    if (e.Message == "Invalid menu selection.")
+                                    {
+                                        selectReplay = false;
+                                    }
+                                    else
+                                    {
+                                        Console.WriteLine(e.Message);
+                                        startMenuValid = false;
+                                    }
+                                }
+                            } while (!selectReplay);
+                        }
                     }
-                }
-                catch (Exception e)
-                {
-                    // Throw error message if invalid move is made
-                    Console.WriteLine(e.Message);
-                    moveValid = false;
-                }
-            }
-            // Repeat while move is invalid or neither player has won
-            while (!moveValid || !winner);
-            
-            if (winner)
-            {
-                // Display congratulatory message to winner
-                display.Winner(game.CurrentPlayer());
-            }
-            Console.ReadLine();
+                    catch (Exception e)
+                    {
+                        Console.WriteLine(e.Message);
+                        startMenuValid = false;
+                    }
+                } while (!startMenuValid);
+            } while (restart);
         }
     }
 }


### PR DESCRIPTION
All games played per session are now stored, and previous games can be replayed.

- Updated Display class to include StartMenu() and GetStartMenuSelection() methods which allow user to select from "1. Start New Game" or "2. Replay Previous Game"
- Updated Display class to ensure users navigate back to main menu after game win by pressing any key
- Updated Display class to include ReplayGame() method which allows user to select from list of previous games and have one replayed in 'live action'
- Updated Display class to include ReverseMoves() method, used by ReplayGame() method to reverse stack of game moves to the order in which they were played
- Updated Game class to ensure each game has its own board property
- Updated Program class to store multiple games in List collection, and incorporate the methods mentioned above, returning to start menu where appropriate